### PR TITLE
Updated README.md to authorize docker to connect to X11 server

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ We'll now modify the configuration of the Deepstream application and the IoT Edg
 4. Authorize Docker to connect to X11 server, via a terminal connected to your X11 server running on your Nano device (not via an ssh terminal):
 
     ```bash
-    xhost +local:docker
+    xhost +local:nvidia-docker
     ```
 
 5. Finally, deploy your updated IoT Edge solution:


### PR DESCRIPTION
Currently, the bash command to authorize Docker on the Jetson Nano to connect to the X11 server is incorrect.  This command does not authorize Nvidia-Docker to use the X11 server and will cause the IoT Edge NVIDIADeepStreamSDK module to fail to start.  The module's logs indicate the following error:
> No protocol specified 
> No EGL Display
> nvbufsurftransform: Could not get EGL display connection 

To properly authorize Nvidia-Docker to use the X11 server, you must use the following command instead:
`xhost +local:nvidia-docker` 

This solution was confirmed to work using the [Jetson Nano Developer Kit SD Card Image w/ JP 4.2.3 & Release Date 2019/11/19](https://developer.nvidia.com/jetson-nano-sd-card-image-r3223).

This disk image can be downloaded using the hyperlink above or by going to the [Jetson Download Center](https://developer.nvidia.com/embedded/downloads) and looking for the option that looks like the image below.
![image](https://user-images.githubusercontent.com/19712696/71770646-faa56100-2efc-11ea-8a14-e3bbf9cc2ea8.png)

